### PR TITLE
Add default API key

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+import os
+from flask import Flask, request, jsonify, render_template
+import openai
+
+# For convenience, a placeholder key is used when the OPENAI_API_KEY
+# environment variable is not defined. Replace ``sk-testkey`` with a
+# real key if needed.
+openai.api_key = os.environ.get('OPENAI_API_KEY', 'sk-testkey')
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json()
+    message = data.get('message', '')
+    if not message:
+        return jsonify({'error': 'No message provided'}), 400
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": message}]
+        )
+        reply = response.choices[0].message['content']
+        return jsonify({'reply': reply})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8">
+    <title>Chat IA</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        #chat { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+        .user { color: blue; }
+        .bot { color: green; }
+    </style>
+</head>
+<body>
+    <div id="chat"></div>
+    <input type="text" id="message" placeholder="Digite sua mensagem" style="width:80%"> 
+    <button id="send">Enviar</button>
+
+<script>
+$(function() {
+    $('#send').on('click', function() {
+        const msg = $('#message').val();
+        if(!msg) return;
+        $('#chat').append('<div class="user"><strong>Você:</strong> ' + msg + '</div>');
+        $('#message').val('');
+        $.ajax({
+            url: '/chat',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({message: msg}),
+            success: function(data) {
+                $('#chat').append('<div class="bot"><strong>Bot:</strong> ' + data.reply + '</div>');
+                $('#chat').scrollTop($('#chat')[0].scrollHeight);
+            },
+            error: function(err) {
+                $('#chat').append('<div class="bot"><strong>Erro:</strong> ' + err.responseJSON.error + '</div>');
+            }
+        });
+    });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set a placeholder OpenAI API key in `app.py`

## Testing
- `pytest -q`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68424a0864648321a2481560d4a32fba